### PR TITLE
Basic portable mode

### DIFF
--- a/src/main/java/de/onyxbits/raccoon/App.java
+++ b/src/main/java/de/onyxbits/raccoon/App.java
@@ -9,6 +9,7 @@ import com.akdeniz.googleplaycrawler.GooglePlayAPI;
 import de.onyxbits.raccoon.gui.MainActivity;
 import de.onyxbits.raccoon.io.Archive;
 import de.onyxbits.raccoon.rss.Loader;
+import de.onyxbits.raccoon.util.EmptyPreferencesFactory;
 
 /**
  * Just the application launcher.
@@ -56,6 +57,11 @@ public class App {
 	 * @throws ParseException
 	 */
 	public static void main(String[] args) throws ParseException {
+		if (System.getProperty("raccoon.portable") != null && "true".equals(System.getProperty("raccoon.portable"))) {
+			// provide empty preferences that do not store anything in portable mode
+			System.setProperty("java.util.prefs.PreferencesFactory", EmptyPreferencesFactory.class.getName());
+		}
+
 		getDir(HOMEDIR).mkdirs();
 		getDir(EXTDIR).mkdirs();
 		getDir(CACHEDIR).mkdirs();

--- a/src/main/java/de/onyxbits/raccoon/util/EmptyPreferences.java
+++ b/src/main/java/de/onyxbits/raccoon/util/EmptyPreferences.java
@@ -1,0 +1,20 @@
+package de.onyxbits.raccoon.util;
+
+import java.util.prefs.AbstractPreferences;
+import java.util.prefs.BackingStoreException;
+
+/**
+ * Empty preferences that do not provide or store any value
+ */
+public class EmptyPreferences extends AbstractPreferences {
+	protected EmptyPreferences() { super(null, ""); }
+	@Override protected AbstractPreferences childSpi(String name) { return new EmptyPreferences(); }
+	@Override protected String[] childrenNamesSpi() throws BackingStoreException { return new String[0]; }
+	@Override protected void flushSpi() throws BackingStoreException {}
+	@Override protected String getSpi(String key) { return null; }
+	@Override protected String[] keysSpi() throws BackingStoreException { return new String[0]; }
+	@Override protected void putSpi(String key, String value) {}
+	@Override protected void removeNodeSpi() throws BackingStoreException {}
+	@Override protected void removeSpi(String key) {}
+	@Override protected void syncSpi() throws BackingStoreException {}
+}

--- a/src/main/java/de/onyxbits/raccoon/util/EmptyPreferencesFactory.java
+++ b/src/main/java/de/onyxbits/raccoon/util/EmptyPreferencesFactory.java
@@ -1,0 +1,13 @@
+package de.onyxbits.raccoon.util;
+
+import java.util.prefs.Preferences;
+import java.util.prefs.PreferencesFactory;
+
+/**
+ * Factory for EmptyPreferences
+ * @see EmptyPreferences
+ */
+public class EmptyPreferencesFactory implements PreferencesFactory {
+	@Override public Preferences systemRoot() { return new EmptyPreferences(); }
+	@Override public Preferences userRoot() { return new EmptyPreferences(); }
+}


### PR DESCRIPTION
I noticed that Raccoon wants to write to the registry when running in windows, so I implemented this basic portable mode. It works by adding a new Preference implementation (EmptyPreferences) which
does not provide or store any preferences. It is activated by setting the system
property 'raccoon.portable=true'.

This allows you to run Raccoon in portable mode like so:
java "-Draccoon.home=$PWD" "-Draccoon.portable=true" -jar raccoon.jar (sh, ps)
java "-Draccoon.home=%cd%" "-Draccoon.portable=true" -jar raccoon.jar (cmd)

In the future we could also implement a Preference provider that does actually store the preferences into a file in _raccoon.home_. (or rather use an implementation of someone else)
