### PR TITLE
Enabled proxy authentication, read credentials from network.cfg

### DIFF
--- a/src/main/java/de/onyxbits/raccoon/App.java
+++ b/src/main/java/de/onyxbits/raccoon/App.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 
 import javax.swing.SwingUtilities;
 import org.apache.commons.cli.ParseException;
+import org.apache.http.client.HttpClient;
 import com.akdeniz.googleplaycrawler.GooglePlayAPI;
 import de.onyxbits.raccoon.gui.MainActivity;
 import de.onyxbits.raccoon.io.Archive;
@@ -119,8 +120,9 @@ public class App {
 		String aid = archive.getAndroidId();
 		GooglePlayAPI ret = new GooglePlayAPI(uid, pwd, aid);
 
-		if (archive.getProxyClient() != null) {
-			ret.setClient(archive.getProxyClient());
+		HttpClient client = archive.getProxyClient();
+		if (client != null) {
+			ret.setClient(client);
 		}
 		// I am not quite sure if this method needs to be synchronized, but if so,
 		// this is why:

--- a/src/main/java/de/onyxbits/raccoon/io/Archive.java
+++ b/src/main/java/de/onyxbits/raccoon/io/Archive.java
@@ -11,6 +11,8 @@ import java.util.Properties;
 import java.util.Vector;
 
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -58,6 +60,8 @@ public class Archive {
 	public static final String ANDROIDID = "androidid";
 	public static final String PROXYHOST = "proxyhost";
 	public static final String PROXYPORT = "proxyport";
+	public static final String PROXYUSER = "proxyuser";
+	public static final String PROXYPASS = "proxypass";
 
 	private File root;
 
@@ -169,6 +173,8 @@ public class Archive {
 			cfg.load(new FileInputStream(cfgfile));
 			String ph = cfg.getProperty(PROXYHOST, null);
 			String pp = cfg.getProperty(PROXYPORT, null);
+			String pu = cfg.getProperty(PROXYUSER, null);
+			String pw = cfg.getProperty(PROXYPASS, null);
 			if (ph == null || pp == null) {
 				return null;
 			}
@@ -177,10 +183,14 @@ public class Archive {
 			connManager.setMaxTotal(100);
 			connManager.setDefaultMaxPerRoute(30);
 
-			HttpClient client = new DefaultHttpClient(connManager);
+			DefaultHttpClient client = new DefaultHttpClient(connManager);
 			client.getConnectionManager().getSchemeRegistry().register(Utils.getMockedScheme());
 			HttpHost proxy = new HttpHost(ph, Integer.parseInt(pp));
 			client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+			if (pu != null && pw != null) {
+				client.getCredentialsProvider().setCredentials(new AuthScope(proxy),
+						new UsernamePasswordCredentials(pu, pw));
+			}
 			return client;
 		}
 		return null;


### PR DESCRIPTION
I introduced two variables in network.cfg to enable authentication when the proxy requires this. I could also provide an UI, but as I understand from the Raccoon Handbook this is discouraged.